### PR TITLE
fixes #30 Mark #_ prefixed forms as metadata.

### DIFF
--- a/src/main/kotlin/com/github/simy4/alabaster/ClojureAnnotator.kt
+++ b/src/main/kotlin/com/github/simy4/alabaster/ClojureAnnotator.kt
@@ -13,29 +13,35 @@ import cursive.psi.api.ClListLike
 class ClojureAnnotator: Annotator {
   override fun annotate(element: PsiElement, holder: AnnotationHolder) {
     val elementType = element.elementType
-    if (ClojureTokenTypes.SYMBOL_TOKEN == elementType) {
-      (element.parent.parent as? ClListLike)
-        ?.takeIf { it.type == ClojurePsiElement.LIST }
-        ?.let { list ->
-          val head = list.headText
-          when (head) {
-            "def"
-              , "defn"
-              , "defn-"
-              , "defmulti"
-              , "defmethod"
-              , "defmacro"
-              , "deftest"
-              , "definterface"
-              , "defprotocol"
-              , "deftype" ->
-                if (element.text !== head) {
-                  holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
-                    .textAttributes(DefaultLanguageHighlighterColors.FUNCTION_DECLARATION)
-                    .create()
-                }
+    when (elementType) {
+      ClojureTokenTypes.SYMBOL_TOKEN ->
+        (element.parent.parent as? ClListLike)
+          ?.takeIf { it.type == ClojurePsiElement.LIST }
+          ?.let { list ->
+            when (val head = list.headText) {
+              "def"
+                , "defn"
+                , "defn-"
+                , "defmulti"
+                , "defmethod"
+                , "defmacro"
+                , "deftest"
+                , "definterface"
+                , "defprotocol"
+                , "deftype" ->
+                  if (element.text !== head) {
+                    holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
+                      .textAttributes(DefaultLanguageHighlighterColors.FUNCTION_DECLARATION)
+                      .create()
+                  }
+            }
           }
-      }
+      ClojureTokenTypes.SEXP_COMMENT ->
+        if (element.firstChild.elementType === ClojureTokenTypes.UNEVAL) {
+          holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
+            .textAttributes(DefaultLanguageHighlighterColors.METADATA)
+            .create()
+        }
     }
   }
 }


### PR DESCRIPTION
Final result looks like this:

<img width="491" height="303" alt="Screenshot 2026-02-07 at 7 31 25 pm" src="https://github.com/user-attachments/assets/487fffca-9ea3-40f0-818e-853f76eeb1ac" />
